### PR TITLE
Fix issue with sometimes odd csproj PackageReference declaration.

### DIFF
--- a/packagereference.js
+++ b/packagereference.js
@@ -26,7 +26,7 @@ module.exports.list = function (dir) {
         return itemGroup.filter(a => a && a.PackageReference).map(a => a.PackageReference.map(x => {
             return {
                 id: x.$.Include,
-                version: x.$.Version,
+                version: x.$.Version ?? x.Version[0],
                 targetFramework: null
             }
         })).reduce((ret, cur) => ret.concat(cur), []);


### PR DESCRIPTION
Sometimes x.$.Version is undefined because sometimes IDEs across platforms like to do things like lay out PackageReference differently. 

eg. 
```
<PackageReference Include="Xamarin.Firebase.Messaging" Version="71.1740.4" />
<PackageReference Include="Plugin.CurrentActivity">
    <Version>2.1.0.4</Version>
</PackageReference>
```

This pr will fix Version being undefined in the Plugin.CurrentActivity example above by selecting its first child node.